### PR TITLE
Fix redirection issue at `account` and other minor fixes

### DIFF
--- a/components/AccountBaseTemplate.tsx
+++ b/components/AccountBaseTemplate.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 import { NavigationPanel } from "@/components/NavigationPanel";
 import BaseTemplate from "@/components/BaseTemplate";
-import { useMeDetailsQuery } from "@/saleor/api";
 import { useRouter } from "next/router";
+import { useAuthState } from "@saleor/sdk";
 
 interface AccountBaseTemplateProps {
   children: React.ReactNode;
@@ -12,20 +12,19 @@ const AccountBaseTemplate: React.VFC<AccountBaseTemplateProps> = ({
   children,
 }) => {
   const router = useRouter();
-  const { data, loading } = useMeDetailsQuery();
-  if (loading) {
+  const { authenticated, authenticating } = useAuthState();
+  if (authenticating) {
     return <BaseTemplate isLoading={true} />;
   }
-  if (!data?.me?.id) {
-    router.push("/account/login");
-    // todo: resolve issue with auth token not automatically added to the client
-    // because application stuck in redirecting ATM
-    // router.push({
-    //   pathname: "/account/login",
-    //   query: { next: "/account/accountPreferences" },
-    // });
+
+  if (!authenticated && process.browser) {
+    router.push({
+      pathname: "/account/login",
+      query: { next: router?.pathname },
+    });
     return null;
   }
+
   return (
     <BaseTemplate>
       <div className="py-10">

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -121,7 +121,7 @@ export const Navbar: React.VFC = ({}) => {
                           className="text-gray-700 flex justify-between w-full px-4 py-2 text-sm leading-5 text-left"
                           role="menuitem"
                         >
-                          Account settings
+                          Account preferences
                         </a>
                       </Link>
                     </div>

--- a/components/NavigationPanel.tsx
+++ b/components/NavigationPanel.tsx
@@ -10,7 +10,7 @@ export const NavigationPanel: React.VFC<NavigationPanelProps> = ({
 }) => {
   return (
     <div className="group w-4/5 cursor-default rounded-md bg-white">
-      <Link href="/account/accountPreferences">
+      <Link href="/account/preferences">
         <a className="text-black">
           <span
             className={clsx(


### PR DESCRIPTION
- before account section triggers the redirection, now it waits for token refresh operation. Too early redirections are resolved now.
- fix account section link
- unify menu naming 